### PR TITLE
Make kubexp compilable on macOS with multi-arch support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,13 @@
  #!/bin/bash
 ./gitinfo.sh
-if [ $GOOS = "windows" ]; then
+if [ "$GOOS" = "windows" ]; then
     executable="$1/kubexp.exe"
-else 
+else
     executable="$1/kubexp"
 fi
-export GOARCH=amd64
-echo "building $GOARCH $GOOS  $executable ..."
+GOOS=${GOOS:-"$(go env GOOS)"}
+GOARCH=${GOARCH:-"$(go env GOARCH)"}
+echo "building $GOOS $GOARCH $executable ..."
 # go build -o $executable github.com/alitari/kubexp/main
 go build -o $executable ./main
 chmod a+x $executable

--- a/executeCmd_unix.go
+++ b/executeCmd_unix.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build linux || darwin
+// +build linux darwin
 
 package kubexp
 

--- a/executeCmd_windows.go
+++ b/executeCmd_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package kubexp


### PR DESCRIPTION
1. `$GOOS` => `"$GOOS"` to silence `./build.sh: line 4: [: ==: unary operator expected`
2. `export GOARCH=amd64` => `GOARCH=${GOARCH:-"$(go env GOARCH)"}`. Then one can either set `GOARCH` explicitly or use the default value.

Testing done:
1. `export GOOS="darwin"` then `./build.sh bin` on my M1 MBP, the binary looks good
```
file ./bin/kubexp
./bin/kubexp: Mach-O 64-bit executable arm64
```
2. `export GOOS="linux"` then `./build.sh bin` on my M1 MBP, the binary looks good
```
file ./bin/kubexp
./bin/kubexp: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=19KD2_riyTCDCqpF62-j/q1Y6r2Tx4kRuuN-RHaIb/RNjGamP6OW-XvNrBEa6I/OvkJHLfa7ouymPkej9NE, not stripped
```
3. `export GOOS="windows"` then `./build.sh bin` on my M1 MBP, the binary looks good
```
file ./bin/kubexp.exe
./bin/kubexp.exe: PE32+ executable (console) Aarch64 (stripped to external PDB), for MS Windows
```
